### PR TITLE
Bumping up libraries versions

### DIFF
--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/FileSystemResultsWriter.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/FileSystemResultsWriter.kt
@@ -3,13 +3,14 @@ package io.qameta.allure.kotlin
 import io.qameta.allure.kotlin.model.TestResult
 import io.qameta.allure.kotlin.model.TestResultContainer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.util.*
 
 class FileSystemResultsWriter(private val outputDirectory: File) : AllureResultsWriter {
-    private val mapper: Json = Json.indented
+    private val mapper: Json = Json(JsonConfiguration(prettyPrint = true, useArrayPolymorphism = true))
 
     override fun write(testResult: TestResult) {
         val testResultName = generateTestResultName(testResult.uuid)

--- a/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/AllureLifecycleTest.kt
+++ b/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/AllureLifecycleTest.kt
@@ -8,7 +8,7 @@ import io.qameta.allure.kotlin.model.FixtureResult
 import io.qameta.allure.kotlin.model.StepResult
 import io.qameta.allure.kotlin.model.TestResult
 import io.qameta.allure.kotlin.model.TestResultContainer
-import io.qameta.allure.kotlin.util.extractor
+import io.qameta.allure.kotlin.test.function
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -109,7 +109,7 @@ class AllureLifecycleTest {
             .hasFieldOrPropertyWithValue("uuid", uuid)
             .hasFieldOrPropertyWithValue("name", name)
         Assertions.assertThat(actual.steps)
-            .flatExtracting(extractor(StepResult::name))
+            .flatExtracting(function(StepResult::name))
             .containsExactly(firstStepName, secondStepName)
     }
 
@@ -145,7 +145,7 @@ class AllureLifecycleTest {
             .hasFieldOrPropertyWithValue("name", name)
             .hasFieldOrPropertyWithValue("fullName", fullName)
         Assertions.assertThat(actual.steps)
-            .flatExtracting(extractor(StepResult::name))
+            .flatExtracting(function(StepResult::name))
             .containsExactly(stepName)
     }
 
@@ -199,7 +199,7 @@ class AllureLifecycleTest {
             .hasFieldOrPropertyWithValue("name", firstName)
         Assertions.assertThat(fixtureResult.steps)
             .hasSize(2)
-            .flatExtracting(extractor(StepResult::name))
+            .flatExtracting(function(StepResult::name))
             .containsExactly(firstStepName, secondStepName)
     }
 

--- a/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/util/JavaInterop.kt
+++ b/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/util/JavaInterop.kt
@@ -1,5 +1,0 @@
-package io.qameta.allure.kotlin.util
-
-import org.assertj.core.api.iterable.Extractor
-
-fun <T> extractor(extraction: (T) -> Any?): Extractor<T, Any?> = Extractor { extraction(it) }

--- a/allure-kotlin-junit4/src/test/kotlin/io/qameta/allure/kotlin/junit4/AllureJunit4Test.kt
+++ b/allure-kotlin-junit4/src/test/kotlin/io/qameta/allure/kotlin/junit4/AllureJunit4Test.kt
@@ -17,7 +17,6 @@ import io.qameta.allure.kotlin.test.function
 import io.qameta.allure.kotlin.util.ResultsUtils.HOST_LABEL_NAME
 import io.qameta.allure.kotlin.util.ResultsUtils.THREAD_LABEL_NAME
 import org.assertj.core.api.Assertions
-import org.assertj.core.api.iterable.Extractor
 import org.junit.jupiter.api.Test
 import org.junit.runner.JUnitCore
 
@@ -145,7 +144,7 @@ class AllureJunit4Test {
         val testResults = results.testResults
         Assertions.assertThat(testResults)
             .hasSize(2)
-            .flatExtracting(extractor(TestResult::status))
+            .flatExtracting(function(TestResult::status))
             .containsExactly(Status.SKIPPED, Status.SKIPPED)
     }
 
@@ -194,7 +193,7 @@ class AllureJunit4Test {
 
         Assertions.assertThat(testResults.flatMap { it.steps })
             .hasSize(2)
-            .extracting(extractor(StepResult::name))
+            .extracting(function(StepResult::name))
             .containsExactly("Step 1", "Step 2")
     }
 
@@ -328,5 +327,3 @@ class AllureJunit4Test {
         }
     }
 }
-
-private fun <T, R> extractor(extraction: (T) -> R): Extractor<T, R> = Extractor { extraction(it) }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,14 +1,14 @@
 object Versions {
-    const val kotlin = "1.3.61"
-    const val kontlinxSerialization = "0.14.0"
+    const val kotlin = "1.3.71"
+    const val kontlinxSerialization = "0.20.0"
 
     const val junit4 = "4.12"
     const val junit5 = "5.5.2"
-    const val junitExtensions = "2.3.0"
+    const val junitExtensions = "2.4.0"
 
-    const val assertJ = "3.11.1"
+    const val assertJ = "3.15.0"
 
     const val mockk = "1.9.3"
 
-    const val randomBeans = "3.8.0"
+    const val randomBeans = "3.9.0"
 }


### PR DESCRIPTION
* replacing deprecated `Json` configuration with appropriate one
* removing deprecated `extractor` functions from `assertj`