### PR TITLE
Allure Android implementation

### DIFF
--- a/allure-kotlin-android/build.gradle.kts
+++ b/allure-kotlin-android/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
     implementation("androidx.test.ext:junit:${Versions.Android.Test.junit}")
     implementation("androidx.test:runner:${Versions.Android.Test.runner}")
     implementation("androidx.multidex:multidex:${Versions.Android.multiDex}")
+    implementation("androidx.test.uiautomator:uiautomator:${Versions.Android.Test.uiAutomator}")
 }

--- a/allure-kotlin-android/build.gradle.kts
+++ b/allure-kotlin-android/build.gradle.kts
@@ -31,4 +31,5 @@ dependencies {
     implementation(kotlin("stdlib-jdk7", Versions.kotlin))
     implementation("androidx.test.ext:junit:${Versions.Android.Test.junit}")
     implementation("androidx.test:runner:${Versions.Android.Test.runner}")
+    implementation("androidx.multidex:multidex:${Versions.Android.multiDex}")
 }

--- a/allure-kotlin-android/src/main/AndroidManifest.xml
+++ b/allure-kotlin-android/src/main/AndroidManifest.xml
@@ -1,5 +1,1 @@
-<manifest xmlns:tools="http://schemas.android.com/tools"
-    package="io.qameta.allure.android">
-
-    <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
-</manifest>
+<manifest package="io.qameta.allure.android" />

--- a/allure-kotlin-android/src/main/AndroidManifest.xml
+++ b/allure-kotlin-android/src/main/AndroidManifest.xml
@@ -1,2 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.qameta.allure.android" />
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    package="io.qameta.allure.android">
+
+    <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
+</manifest>

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureAndroidLifecycle.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureAndroidLifecycle.kt
@@ -1,7 +1,6 @@
 package io.qameta.allure.android
 
 import android.os.Environment
-import io.qameta.allure.android.internal.isDeviceTest
 import io.qameta.allure.kotlin.AllureLifecycle
 import io.qameta.allure.kotlin.FileSystemResultsWriter
 import io.qameta.allure.kotlin.util.PropertiesUtils
@@ -10,16 +9,10 @@ import java.io.File
 object AllureAndroidLifecycle : AllureLifecycle(writer = FileSystemResultsWriter(obtainResultsDirectory()))
 
 /**
- * Obtains results directory as a [File] reference. It takes into consideration the results directory specified via **allure.results.directory** property.
- * For device tests it uses the external storage to save the results.
+ * Obtains results directory as a [File] reference.
+ * It takes into consideration the results directory specified via **allure.results.directory** property.
  */
 private fun obtainResultsDirectory(): File {
     val defaultAllurePath = PropertiesUtils.resultsDirectoryPath
-    return when {
-        isDeviceTest() -> File(
-            Environment.getExternalStorageDirectory(),
-            defaultAllurePath
-        )
-        else -> File(defaultAllurePath)
-    }
+    return File(Environment.getExternalStorageDirectory(), defaultAllurePath)
 }

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureAndroidLifecycle.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureAndroidLifecycle.kt
@@ -1,0 +1,25 @@
+package io.qameta.allure.android
+
+import android.os.Environment
+import io.qameta.allure.android.internal.isDeviceTest
+import io.qameta.allure.kotlin.AllureLifecycle
+import io.qameta.allure.kotlin.FileSystemResultsWriter
+import io.qameta.allure.kotlin.util.PropertiesUtils
+import java.io.File
+
+object AllureAndroidLifecycle : AllureLifecycle(writer = FileSystemResultsWriter(obtainResultsDirectory()))
+
+/**
+ * Obtains results directory as a [File] reference. It takes into consideration the results directory specified via **allure.results.directory** property.
+ * For device tests it uses the external storage to save the results.
+ */
+private fun obtainResultsDirectory(): File {
+    val defaultAllurePath = PropertiesUtils.resultsDirectoryPath
+    return when {
+        isDeviceTest() -> File(
+            Environment.getExternalStorageDirectory(),
+            defaultAllurePath
+        )
+        else -> File(defaultAllurePath)
+    }
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
@@ -1,0 +1,42 @@
+package io.qameta.allure.android
+
+import android.app.UiAutomation
+import android.graphics.Bitmap
+import android.util.Log
+import androidx.annotation.IntRange
+import androidx.test.platform.app.InstrumentationRegistry
+import io.qameta.allure.kotlin.Allure
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+private const val TAG = "AllureScreenshot"
+
+/**
+ * Takes a screenshot of a device in a given [quality] and attaches it to current step or test run.
+ * Quality must be in range [0..100] or an exception will be thrown
+ *
+ * It uses [android.app.UiAutomation] under the hood to take the screenshot (just like the UiAutomator).
+ *
+ * @return true if screen shot is created and attached successfully, false otherwise
+ */
+@Suppress("unused")
+fun allureScreenshot(name: String = "screenshot", @IntRange(from = 0, to = 100) quality: Int = 90): Boolean {
+    require(quality in (0..100)) { "quality must be 0..100" }
+    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation ?: return false.also {
+        Log.e(TAG, "UiAutomation is unavailable. Can't take the screenshot")
+    }
+    val inputStream = uiAutomation.takeScreenshot(quality) ?: return false.also {
+        Log.e(TAG, "Failed to take the screenshot")
+    }
+    Allure.attachment(name = name, content = inputStream, type = "image/png", fileExtension = ".png")
+    return true
+}
+
+private fun UiAutomation.takeScreenshot(quality: Int): InputStream? {
+    val screenshot = takeScreenshot() ?: return null
+    return ByteArrayOutputStream()
+        .apply { screenshot.compress(Bitmap.CompressFormat.PNG, quality, this) }
+        .toByteArray()
+        .inputStream()
+        .also { screenshot.recycle() }
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
@@ -15,7 +15,6 @@ private const val TAG = "AllureScreenshot"
  * Quality must be in range [0..100] or an exception will be thrown.
  *
  * It uses [androidx.test.uiautomator.UiDevice] to take the screenshot.
- * Available since API 18, no effect for other versions.
  *
  * @return true if screen shot is created and attached successfully, false otherwise
  */

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/AllureScreenshot.kt
@@ -1,42 +1,43 @@
 package io.qameta.allure.android
 
-import android.app.UiAutomation
-import android.graphics.Bitmap
 import android.util.Log
 import androidx.annotation.IntRange
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import io.qameta.allure.android.internal.createTemporaryFile
+import io.qameta.allure.android.internal.uiDevice
 import io.qameta.allure.kotlin.Allure
-import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
 private const val TAG = "AllureScreenshot"
 
 /**
- * Takes a screenshot of a device in a given [quality] and attaches it to current step or test run.
- * Quality must be in range [0..100] or an exception will be thrown
+ * Takes a screenshot of a device in a given [quality] & [scale], after that attaches it to current step or test run.
+ * Quality must be in range [0..100] or an exception will be thrown.
  *
- * It uses [android.app.UiAutomation] under the hood to take the screenshot (just like the UiAutomator).
+ * It uses [androidx.test.uiautomator.UiDevice] to take the screenshot.
+ * Available since API 18, no effect for other versions.
  *
  * @return true if screen shot is created and attached successfully, false otherwise
  */
 @Suppress("unused")
-fun allureScreenshot(name: String = "screenshot", @IntRange(from = 0, to = 100) quality: Int = 90): Boolean {
+fun allureScreenshot(
+    name: String = "screenshot",
+    @IntRange(from = 0, to = 100) quality: Int = 90,
+    scale: Float = 1.0f
+): Boolean {
     require(quality in (0..100)) { "quality must be 0..100" }
-    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation ?: return false.also {
+    val uiDevice = uiDevice ?: return false.also {
         Log.e(TAG, "UiAutomation is unavailable. Can't take the screenshot")
     }
-    val inputStream = uiAutomation.takeScreenshot(quality) ?: return false.also {
+    val inputStream = uiDevice.takeScreenshot(scale, quality) ?: return false.also {
         Log.e(TAG, "Failed to take the screenshot")
     }
     Allure.attachment(name = name, content = inputStream, type = "image/png", fileExtension = ".png")
     return true
 }
 
-private fun UiAutomation.takeScreenshot(quality: Int): InputStream? {
-    val screenshot = takeScreenshot() ?: return null
-    return ByteArrayOutputStream()
-        .apply { screenshot.compress(Bitmap.CompressFormat.PNG, quality, this) }
-        .toByteArray()
-        .inputStream()
-        .also { screenshot.recycle() }
+private fun UiDevice.takeScreenshot(scale: Float, quality: Int): InputStream? {
+    val tempFile = createTemporaryFile(prefix = "screenshot")
+    if (!takeScreenshot(tempFile, scale, quality)) return null
+    return tempFile.inputStream()
 }

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
@@ -1,0 +1,26 @@
+package io.qameta.allure.android.internal
+
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.test.runner.permission.PermissionRequester
+
+/**
+ * Gives information about the environment in which the tests are running:
+ *  - @return true for Android device (real device or emulator)
+ *  - @return false for emulated environment of Robolectric
+ *
+ * This is the same logic as present in [androidx.test.ext.junit.runners.AndroidJUnit4] for resolving class runner.
+ */
+@SuppressLint("DefaultLocale")
+internal fun isDeviceTest(): Boolean =
+    System.getProperty("java.runtime.name")?.toLowerCase()?.contains("android") ?: false
+
+internal fun requestExternalStoragePermissions() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+
+    with(PermissionRequester()) {
+        addPermissions("android.permission.WRITE_EXTERNAL_STORAGE")
+        addPermissions("android.permission.READ_EXTERNAL_STORAGE")
+        requestPermissions()
+    }
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
@@ -2,7 +2,10 @@ package io.qameta.allure.android.internal
 
 import android.annotation.SuppressLint
 import android.os.Build
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.permission.PermissionRequester
+import androidx.test.uiautomator.UiDevice
 
 /**
  * Gives information about the environment in which the tests are running:
@@ -24,3 +27,12 @@ internal fun requestExternalStoragePermissions() {
         requestPermissions()
     }
 }
+
+/**
+ * Retrieves [UiDevice] if it's available, otherwise null is returned.
+ * In Robolectric tests [UiDevice] is inaccessible and this property serves as a safe way of accessing it.
+ */
+internal val uiDevice: UiDevice?
+    get() = runCatching { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()) }
+        .onFailure { Log.d("UiDevice", "UiDevice unavailable") }
+        .getOrNull()

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/internal/TestUtils.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.permission.PermissionRequester
 import androidx.test.uiautomator.UiDevice
+import java.io.File
 
 /**
  * Gives information about the environment in which the tests are running:
@@ -34,5 +35,10 @@ internal fun requestExternalStoragePermissions() {
  */
 internal val uiDevice: UiDevice?
     get() = runCatching { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()) }
-        .onFailure { Log.d("UiDevice", "UiDevice unavailable") }
+        .onFailure { Log.e("UiDevice", "UiDevice unavailable") }
         .getOrNull()
+
+internal fun createTemporaryFile(prefix: String = "temp", suffix: String? = null): File {
+    val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
+    return createTempFile(prefix, suffix, cacheDir)
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/listeners/LogcatListener.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/listeners/LogcatListener.kt
@@ -1,0 +1,95 @@
+package io.qameta.allure.android.listeners
+
+import android.util.Log
+import io.qameta.allure.kotlin.listener.ContainerLifecycleListener
+import io.qameta.allure.kotlin.listener.StepLifecycleListener
+import io.qameta.allure.kotlin.listener.TestLifecycleListener
+import io.qameta.allure.kotlin.model.StepResult
+import io.qameta.allure.kotlin.model.TestResult
+import io.qameta.allure.kotlin.model.TestResultContainer
+
+class LogcatListener :
+    ContainerLifecycleListener by LogcatContainerListener(),
+    TestLifecycleListener by LogcatTestLifecycleListener(),
+    StepLifecycleListener by LogcatStepLifecycleListener()
+
+class LogcatContainerListener : ContainerLifecycleListener {
+    override fun beforeContainerStart(container: TestResultContainer) {
+        container.log("START")
+    }
+
+    override fun beforeContainerUpdate(container: TestResultContainer) {
+        container.log("UPDATE")
+    }
+
+    override fun beforeContainerStop(container: TestResultContainer) {
+        container.log("STOP")
+    }
+
+    override fun beforeContainerWrite(container: TestResultContainer) {
+        container.log("WRITE")
+    }
+
+    private fun TestResultContainer.log(action: String) {
+        Log.d(TAG, "$action container: $uuid")
+    }
+
+    companion object {
+        private const val TAG = "LogcatContainerListener"
+    }
+}
+
+class LogcatTestLifecycleListener : TestLifecycleListener {
+
+    override fun beforeTestSchedule(result: TestResult) {
+        result.log("SCHEDULE")
+    }
+
+    override fun beforeTestStart(result: TestResult) {
+        result.log("START")
+    }
+
+    override fun beforeTestUpdate(result: TestResult) {
+        result.log("UPDATE")
+    }
+
+    override fun beforeTestStop(result: TestResult) {
+        result.log("STOP")
+    }
+
+    override fun beforeTestWrite(result: TestResult) {
+        result.log("WRITE")
+    }
+
+    private fun TestResult.log(action: String) {
+        Log.d(TAG, "$action test: $uuid ($fullName)")
+    }
+
+    companion object {
+        private const val TAG = "LogcatTestLifecycle"
+    }
+}
+
+class LogcatStepLifecycleListener : StepLifecycleListener {
+
+    override fun beforeStepStart(result: StepResult) {
+        result.log("START")
+    }
+
+    override fun beforeStepUpdate(result: StepResult) {
+        result.log("UPDATE")
+    }
+
+    override fun beforeStepStop(result: StepResult) {
+        result.log("STOP")
+    }
+
+    private fun StepResult.log(action: String) {
+        Log.d(TAG, "$action step: $name")
+    }
+
+    companion object {
+        private const val TAG = "LogcatStepLifecycle"
+    }
+}
+

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/LogcatRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/LogcatRule.kt
@@ -1,0 +1,56 @@
+package io.qameta.allure.android.rules
+
+import android.app.UiAutomation
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import io.qameta.allure.kotlin.Allure
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Clears logcat before each test and dumps the logcat as an attachment after test failure.
+ */
+class LogcatRule(private val fileName: String = "logcat-dump") : TestRule {
+
+    override fun apply(base: Statement?, description: Description?): Statement = object : Statement() {
+        override fun evaluate() {
+            try {
+                clear()
+                base?.evaluate()
+            } catch (throwable: Throwable) {
+                dump()
+                throw throwable
+            }
+        }
+    }
+
+    private val uiAutomation: UiAutomation?
+        get() = InstrumentationRegistry.getInstrumentation().uiAutomation
+
+    private fun clear() {
+        val uiAutomation = uiAutomation ?: return Unit.also {
+            Log.e(TAG, "UiAutomation is unavailable. Clearing logs failed.")
+        }
+        uiAutomation.executeShellCommand("logcat -c")
+    }
+
+    private fun dump() {
+        val uiAutomation = uiAutomation ?: return Unit.also {
+            Log.e(TAG, "UiAutomation is unavailable. Dumping logs failed.")
+        }
+        val pfd = uiAutomation.executeShellCommand("logcat -d")
+        val inputStream = ParcelFileDescriptor.AutoCloseInputStream(pfd).buffered()
+        Allure.attachment(
+            name = fileName,
+            content = inputStream,
+            type = "text/plain",
+            fileExtension = ".txt"
+        )
+    }
+
+    companion object {
+        private val TAG = LogcatRule::class.java.simpleName
+    }
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
@@ -11,6 +11,7 @@ import kotlin.Result
  * It is then added as an attachment of a test case (with name [screenshotName]).
  *
  * By default, it will take a screenshot at the end of every test case (whether it failed or finished successfully).
+ * Available since API 18, no effect for other versions.
  */
 class ScreenshotRule(
     private val mode: Mode = Mode.END,

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
@@ -1,0 +1,46 @@
+package io.qameta.allure.android.rules
+
+import io.qameta.allure.android.allureScreenshot
+import io.qameta.allure.kotlin.Allure
+import org.junit.rules.*
+import org.junit.runner.Description
+import org.junit.runners.model.*
+import kotlin.Result
+
+/**
+ * Makes screenshot of a device upon an end of a test case based on the specified [mode].
+ * It is then added as an attachment of a test case (with name [screenshotName]).
+ *
+ * By default, it will take a screenshot at the end of every test case (whether it failed or finished successfully).
+ */
+class ScreenshotRule(
+    private val mode: Mode = Mode.END,
+    private val screenshotName: String = "end_screenshot"
+) : TestRule {
+
+    override fun apply(base: Statement?, description: Description?): Statement = object : Statement() {
+        override fun evaluate() {
+            with(runCatching { base?.evaluate() }) {
+                if (canTakeScreenshot(mode)) {
+                    allureScreenshot(screenshotName)
+                }
+                getOrThrow()
+            }
+        }
+    }
+
+    private fun Result<*>.canTakeScreenshot(mode: Mode): Boolean =
+        when (mode) {
+            Mode.END -> true
+            Mode.SUCCESS -> isSuccess
+            Mode.FAILURE -> isFailure
+        }
+
+    enum class Mode {
+        END,
+        SUCCESS,
+        FAILURE
+    }
+
+}
+

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
@@ -11,7 +11,6 @@ import kotlin.Result
  * It is then added as an attachment of a test case (with name [screenshotName]).
  *
  * By default, it will take a screenshot at the end of every test case (whether it failed or finished successfully).
- * Available since API 18, no effect for other versions.
  */
 class ScreenshotRule(
     private val mode: Mode = Mode.END,

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/ScreenshotRule.kt
@@ -1,7 +1,6 @@
 package io.qameta.allure.android.rules
 
 import io.qameta.allure.android.allureScreenshot
-import io.qameta.allure.kotlin.Allure
 import org.junit.rules.*
 import org.junit.runner.Description
 import org.junit.runners.model.*
@@ -15,7 +14,7 @@ import kotlin.Result
  */
 class ScreenshotRule(
     private val mode: Mode = Mode.END,
-    private val screenshotName: String = "end_screenshot"
+    private val screenshotName: String = "end-screenshot"
 ) : TestRule {
 
     override fun apply(base: Statement?, description: Description?): Statement = object : Statement() {

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
@@ -1,0 +1,53 @@
+package io.qameta.allure.android.rules
+
+import android.util.Log
+import androidx.test.uiautomator.UiDevice
+import io.qameta.allure.android.internal.uiDevice
+import io.qameta.allure.kotlin.Allure
+import org.junit.rules.*
+import org.junit.runner.*
+import org.junit.runners.model.*
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+
+/**
+ * Dumps window hierarchy when the test fails and adds it as an attachment to allure results.
+ */
+class WindowHierarchyRule(private val fileName: String = "window-hierarchy") : TestRule {
+
+    override fun apply(base: Statement?, description: Description?): Statement = object : Statement() {
+        override fun evaluate() {
+            runCatching { base?.evaluate() }
+                .onFailure { dumpWindowHierarchy() }
+                .getOrThrow()
+        }
+    }
+
+    private fun dumpWindowHierarchy() {
+        val uiDevice = uiDevice ?: return Unit.also {
+            Log.e(TAG, "UiAutomation is unavailable. Dumping window hierarchy failed.")
+        }
+
+        Allure.attachment(
+            name = fileName,
+            type = "text/xml",
+            fileExtension = ".xml",
+            content = uiDevice.dumpWindowHierarchy()
+        )
+    }
+
+    private fun UiDevice.dumpWindowHierarchy(): ByteArrayInputStream =
+        ByteArrayOutputStream()
+            .apply {
+                waitForIdle(TimeUnit.SECONDS.toMillis(5))
+                dumpWindowHierarchy(this)
+            }
+            .toByteArray()
+            .inputStream()
+
+    companion object {
+        private val TAG = WindowHierarchyRule::class.java.simpleName
+    }
+
+}

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
@@ -13,7 +13,6 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Dumps window hierarchy when the test fails and adds it as an attachment to allure results.
- * Available since API 18, no effect for other versions.
  */
 class WindowHierarchyRule(private val fileName: String = "window-hierarchy") : TestRule {
 

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/rules/WindowHierarchyRule.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Dumps window hierarchy when the test fails and adds it as an attachment to allure results.
+ * Available since API 18, no effect for other versions.
  */
 class WindowHierarchyRule(private val fileName: String = "window-hierarchy") : TestRule {
 

--- a/allure-kotlin-android/src/main/java/io/qameta/allure/android/runners/AllureAndroidJUnitRunners.kt
+++ b/allure-kotlin-android/src/main/java/io/qameta/allure/android/runners/AllureAndroidJUnitRunners.kt
@@ -1,0 +1,80 @@
+package io.qameta.allure.android.runners
+
+import android.os.Bundle
+import androidx.multidex.MultiDex
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.runner.AndroidJUnitRunner
+import io.qameta.allure.android.AllureAndroidLifecycle
+import io.qameta.allure.android.internal.isDeviceTest
+import io.qameta.allure.android.internal.requestExternalStoragePermissions
+import io.qameta.allure.kotlin.Allure
+import io.qameta.allure.kotlin.junit4.AllureJunit4
+import org.junit.runner.*
+import org.junit.runner.manipulation.*
+import org.junit.runner.notification.*
+
+/**
+ * Wrapper over [AndroidJUnit4] that attaches the [AllureJunit4] listener and
+ * grants external storage permissions for tests running on a device (required for the test results to be saved).
+ */
+class AllureAndroidJUnit4(clazz: Class<*>) : Runner(), Filterable, Sortable {
+
+    private val delegate = AndroidJUnit4(clazz)
+
+    override fun run(notifier: RunNotifier?) {
+        notifier?.addListener(createAllureListener())
+        if (isDeviceTest()) {
+            requestExternalStoragePermissions()
+        }
+        delegate.run(notifier)
+    }
+
+    private fun createAllureListener(): AllureJunit4 {
+        return with(AllureAndroidLifecycle) {
+            Allure.lifecycle = this
+            AllureJunit4(this)
+        }
+    }
+
+    override fun getDescription(): Description = delegate.description
+
+    override fun filter(filter: Filter?) = delegate.filter(filter)
+
+    override fun sort(sorter: Sorter?) = delegate.sort(sorter)
+
+}
+
+/**
+ * Custom [AndroidJUnitRunner] that setups [AllureAndroidLifecycle] and attaches [AllureJunit4] listener.
+ * It also automatically grants the external storage permission (required for the test results to be saved).
+ */
+open class AllureAndroidJUnitRunner : AndroidJUnitRunner() {
+
+    override fun onCreate(arguments: Bundle) {
+        Allure.lifecycle = AllureAndroidLifecycle
+        val listenerArg = listOfNotNull(
+            arguments.getCharSequence("listener"),
+            AllureJunit4::class.java.name
+        ).joinToString(separator = ",")
+        arguments.putCharSequence("listener", listenerArg)
+        super.onCreate(arguments)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        requestExternalStoragePermissions()
+    }
+
+}
+
+/**
+ * [AllureAndroidJUnitRunner] that additionally patches the instrumentation context using [MultiDex]
+ */
+open class MultiDexAllureAndroidJUnitRunner : AllureAndroidJUnitRunner() {
+
+    override fun onCreate(arguments: Bundle) {
+        MultiDex.installInstrumentation(context, targetContext)
+        super.onCreate(arguments)
+    }
+}
+

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/Allure.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/Allure.kt
@@ -1,12 +1,14 @@
 package io.qameta.allure.kotlin
 
-import io.qameta.allure.kotlin.model.*
+import io.qameta.allure.kotlin.model.Label
 import io.qameta.allure.kotlin.model.Link
+import io.qameta.allure.kotlin.model.Status
+import io.qameta.allure.kotlin.model.StepResult
+import io.qameta.allure.kotlin.model.TestResult
 import io.qameta.allure.kotlin.util.ExceptionUtils
 import io.qameta.allure.kotlin.util.ResultsUtils
 import java.io.InputStream
-import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.UUID
 
 /**
  * The class contains some useful methods to work with [AllureLifecycle].
@@ -15,6 +17,7 @@ object Allure {
 
     private const val TXT_EXTENSION = ".txt"
     private const val TEXT_PLAIN = "text/plain"
+
     @JvmStatic
     var lifecycle: AllureLifecycle = AllureLifecycle()
 
@@ -233,7 +236,7 @@ object Allure {
     ) {
         lifecycle.addAttachment(
             name = name,
-            body = content.toByteArray(StandardCharsets.UTF_8),
+            body = content.toByteArray(Charsets.UTF_8),
             type = type,
             fileExtension = fileExtension
         )
@@ -267,6 +270,7 @@ object Allure {
      * Step context.
      */
     interface StepContext {
+
         fun name(name: String)
         fun <T> parameter(name: String, value: T): T
     }
@@ -275,6 +279,7 @@ object Allure {
      * Basic implementation of step context.
      */
     private class DefaultStepContext(private val uuid: String) : StepContext {
+
         override fun name(name: String) {
             lifecycle.updateStep(uuid) { it.name = name }
         }

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/AllureLifecycle.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/AllureLifecycle.kt
@@ -15,7 +15,7 @@ import java.io.InputStream
 import java.util.*
 import java.util.logging.Logger
 
-class AllureLifecycle @JvmOverloads constructor(
+open class AllureLifecycle @JvmOverloads constructor(
     private val writer: AllureResultsWriter = getDefaultWriter(),
     private val notifier: LifecycleNotifier = getDefaultNotifier()
 ) {

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/FileSystemResultsWriter.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/FileSystemResultsWriter.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.JsonConfiguration
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.util.*
+import java.util.UUID
 
 class FileSystemResultsWriter(private val outputDirectory: File) : AllureResultsWriter {
     private val mapper: Json = Json(JsonConfiguration(prettyPrint = true, useArrayPolymorphism = true))
@@ -52,7 +52,7 @@ class FileSystemResultsWriter(private val outputDirectory: File) : AllureResults
 
     private fun createDirectories(directory: File) {
         val parent = directory.parentFile
-        if (!parent.exists()) {
+        if (parent?.exists() == false) {
             createDirectories(parent)
         }
         if (!directory.exists() && !directory.mkdirs()) {

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/AnnotationUtils.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/AnnotationUtils.kt
@@ -7,9 +7,7 @@ import io.qameta.allure.kotlin.model.Link
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
-import java.util.*
 import java.util.logging.Logger
-import kotlin.collections.HashSet
 
 /**
  * Collection of utils used by Allure integration to extract meta information from
@@ -17,8 +15,10 @@ import kotlin.collections.HashSet
  *
  */
 object AnnotationUtils {
+
     private val LOGGER: Logger = loggerFor<AnnotationUtils>()
     private const val VALUE_METHOD_NAME = "value"
+
     /**
      * Returns links created from Allure meta annotations specified on annotated element.
      *
@@ -177,9 +177,8 @@ object AnnotationUtils {
                 is Array<*> -> return data.map(Any?::toString)
             }
         }
-        return listOf(Objects.toString(data))
+        return listOf(java.lang.String.valueOf(data))
     }
-
 
     private fun extractRepeatable(annotation: Annotation): List<Annotation> {
         return if (isRepeatableWrapper(annotation)) {

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/ObjectUtils.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/ObjectUtils.kt
@@ -1,10 +1,10 @@
 package io.qameta.allure.kotlin.util
 
-import java.util.*
 import java.util.logging.Logger
 
 object ObjectUtils {
     private val LOGGER: Logger = loggerFor<ObjectUtils>()
+
     /**
      * Returns string representation of given object. Pretty prints arrays.
      *
@@ -27,7 +27,7 @@ object ObjectUtils {
                     is Array<*> -> return data.contentToString()
                 }
             }
-            Objects.toString(data)
+            java.lang.String.valueOf(data)
         } catch (e: Exception) {
             LOGGER.error("Could not convert object to string", e)
             "<NPE>"

--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/ResultsUtils.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/ResultsUtils.kt
@@ -1,8 +1,18 @@
 package io.qameta.allure.kotlin.util
 
-import io.qameta.allure.kotlin.*
-import io.qameta.allure.kotlin.model.*
+import io.qameta.allure.kotlin.Epic
+import io.qameta.allure.kotlin.Feature
+import io.qameta.allure.kotlin.Issue
+import io.qameta.allure.kotlin.Owner
+import io.qameta.allure.kotlin.Severity
+import io.qameta.allure.kotlin.SeverityLevel
+import io.qameta.allure.kotlin.Story
+import io.qameta.allure.kotlin.TmsLink
+import io.qameta.allure.kotlin.model.Label
 import io.qameta.allure.kotlin.model.Link
+import io.qameta.allure.kotlin.model.Parameter
+import io.qameta.allure.kotlin.model.Status
+import io.qameta.allure.kotlin.model.StatusDetails
 import io.qameta.allure.kotlin.util.ObjectUtils.toString
 import io.qameta.allure.kotlin.util.PropertiesUtils.loadAllureProperties
 import java.io.IOException
@@ -12,8 +22,6 @@ import java.lang.management.ManagementFactory
 import java.lang.reflect.Method
 import java.math.BigInteger
 import java.net.InetAddress
-import java.net.UnknownHostException
-import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.logging.Logger
@@ -241,7 +249,6 @@ object ResultsUtils {
             return listOfNotNull(fromProperty, fromEnv).firstOrNull() ?: realThreadName
         }
 
-
     @JvmStatic
     fun getStatus(throwable: Throwable?): Status? {
         return throwable?.let { if (it is AssertionError) Status.FAILED else Status.BROKEN }
@@ -294,11 +301,11 @@ object ResultsUtils {
         parameterTypes: List<String>
     ): String {
         val md = md5Digest.apply {
-            update(className.toByteArray(StandardCharsets.UTF_8))
-            update(methodName.toByteArray(StandardCharsets.UTF_8))
+            update(className.toByteArray(Charsets.UTF_8))
+            update(methodName.toByteArray(Charsets.UTF_8))
         }
         parameterTypes.asSequence()
-            .map { string -> string.toByteArray(StandardCharsets.UTF_8) }
+            .map { string -> string.toByteArray(Charsets.UTF_8) }
             .forEach(md::update)
         val bytes = md.digest()
         return bytesToHex(bytes)
@@ -306,7 +313,7 @@ object ResultsUtils {
 
     @JvmStatic
     fun md5(source: String): String {
-        return bytesToHex(md5Digest.digest(source.toByteArray(StandardCharsets.UTF_8)))
+        return bytesToHex(md5Digest.digest(source.toByteArray(Charsets.UTF_8)))
     }
 
     @JvmStatic
@@ -331,7 +338,7 @@ object ResultsUtils {
     private val realHostName: String
         get() = cachedHost ?: try {
             InetAddress.getLocalHost().hostName ?: "default"
-        } catch (e: UnknownHostException) {
+        } catch (e: Exception) {
             LOGGER.debug("Could not get host name $e")
             "default"
         }.also {
@@ -359,7 +366,7 @@ object ResultsUtils {
     ): String? {
         return try {
             classLoader.getResourceAsStream(resourceName)?.toByteArray()
-                ?.let { String(it, StandardCharsets.UTF_8) }
+                ?.let { String(it, Charsets.UTF_8) }
         } catch (e: IOException) {
             LOGGER.error("Unable to process description resource file", e)
             null

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,6 +20,7 @@ object Versions {
         const val minSdk = 21
 
         const val androidX = "1.1.0"
+        const val multiDex = "2.0.1"
 
         object Test {
             const val runner = "1.2.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,6 +27,7 @@ object Versions {
             const val junit = "1.1.1"
             const val espresso = "3.2.0"
             const val robolectric = "4.3.1"
+            const val uiAutomator = "2.2.0"
         }
     }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -17,7 +17,7 @@ object Versions {
 
         const val compileSdk = 28
         const val targetSdk = 28
-        const val minSdk = 15
+        const val minSdk = 18
 
         const val androidX = "1.1.0"
         const val multiDex = "2.0.1"


### PR DESCRIPTION
New allure android implementation. All of the features of the original [allure-android ](https://github.com/allure-framework/allure-android) were migrated, with small changes that make the API more robust.

Content:
* Migrating `Rules`
* Migrating `LogcatListener`
* Implementing screenshot taking
  * implementing `allureScreenshot` for taking screenshots and attaching them to test results
  * using `UiAutomation` for taking screenshot in instrumentation tests and logging an exception in Robolectric tests
  * allowing for specifying the quality of the image
* Defining lifecycle and runners
  * defining runners that setup the lifecycle, listeners & required permissions
    * adding class runner
    * adding instrumentation runners
  * creating `AllureAndroidLifecycle` that uses appropriate results directory for different test types (device or robolectric)
    * adding logic for resolving the target directory
    * opening `AllureLifecycle.kt`
  * adding documentation
  * adding utility functions that are not exposed as an API
* Fixing NPE in FileSystemResultsWriter.kt
Fixing `AllureAndroidJUnit4` adding multiple listener in instrumentation tests
  * RCA: android instrumentation runner shares the `RunNotifier` between class runners, which results in the allure listener being added in each class runner (that leads to duplicated results)
  * FIX:
    * adding listener only once, when the `AllureAndroidLifecycle` has not yet been defined as default `Allure.lifecycle`
    * using default lifecycle for robolectric tests
    * changing `AllureAndroidLifecycle.kt` to be used only for device tests
    * adding documentation


_Note: PR with sample usage and support for the updated target API to follow`_ 