### PR TITLE
Update libraries

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,19 +1,19 @@
 object Versions {
-    const val kotlin = "1.4.21"
-    const val kontlinxSerialization = "1.0.1"
+    const val kotlin = "1.4.32"
+    const val kontlinxSerialization = "1.1.0"
 
-    const val junit4 = "4.13.1"
+    const val junit4 = "4.13.2"
     const val junit5 = "5.5.2"
     const val junitExtensions = "2.4.0"
 
-    const val assertJ = "3.18.1"
+    const val assertJ = "3.19.0"
 
-    const val mockk = "1.10.0"
+    const val mockk = "1.10.6"
 
     const val randomBeans = "3.9.0"
 
     object Android {
-        const val gradlePlugin = "4.0.1"
+        const val gradlePlugin = "4.1.3"
 
         const val compileSdk = 30
         const val targetSdk = 30


### PR DESCRIPTION
### Libraries updated
- Kotlin 1.4.32
- Kotlin serialization 1.1.0
- Android Gradle plugin 4.1.3
- Testing libraries updates

### Notes
- Newer versions of JUnit 5 (5.7.1) and Mockk (1.11.0) can't be used because they require Java 1.8 
- Gradle version can't be updated to 7.0 because "maven" plugin was deprecated and removed in Gradle 7.0 and "maven-publish" must be used instead of it