### PR TITLE
Fix extracting Labels and Links from super-classes

### DIFF
--- a/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/AnnotationUtils.kt
+++ b/allure-kotlin-commons/src/main/kotlin/io/qameta/allure/kotlin/util/AnnotationUtils.kt
@@ -27,7 +27,7 @@ object AnnotationUtils {
      */
     @JvmStatic
     fun getLinks(annotatedElement: AnnotatedElement): Set<Link> {
-        return getLinks(*annotatedElement.declaredAnnotations)
+        return getLinks(*annotatedElement.annotations)
     }
 
     /**
@@ -60,7 +60,7 @@ object AnnotationUtils {
      */
     @JvmStatic
     fun getLabels(annotatedElement: AnnotatedElement): Set<Label> {
-        return getLabels(*annotatedElement.declaredAnnotations)
+        return getLabels(*annotatedElement.annotations)
     }
 
     /**

--- a/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/util/AnnotationUtilsTest.kt
+++ b/allure-kotlin-commons/src/test/kotlin/io/qameta/allure/kotlin/util/AnnotationUtilsTest.kt
@@ -458,5 +458,24 @@ class AnnotationUtilsTest {
                 Assertions.tuple("owner", "tester2")
             )
     }
+
+    @Test
+    fun superClassLabelsShouldPresents() {
+        Assertions.assertThat(getLabels(SubClassWithoutLabelAndLink::class.java))
+                .containsExactly(Label("feature", "super-class-feature"))
+    }
+
+    @Test
+    fun superClassLinksShouldPresents() {
+        Assertions.assertThat(getLinks(SubClassWithoutLabelAndLink::class.java))
+                .extracting(function(Link::url))
+                .containsExactlyInAnyOrder("https://example-url.com")
+    }
+
+    @Feature("super-class-feature")
+    @io.qameta.allure.kotlin.Link("someValue", "someName", "https://example-url.com")
+    abstract class SuperClassWithLabelAndLink
+
+    class SubClassWithoutLabelAndLink : SuperClassWithLabelAndLink()
 }
 


### PR DESCRIPTION
### Context
Labels (features, stories and others) and Links from superclasses do not attached to test results
